### PR TITLE
Parse language tags in description if ExtendedDescription plugin is available.

### DIFF
--- a/include/events.inc.php
+++ b/include/events.inc.php
@@ -8,6 +8,10 @@ Description: Twitter Cards
 
 if (!defined('PHPWG_ROOT_PATH')) die('Hacking attempt!');
 
+// Try using Extended Descriptions to sanitize multi-lingual description tag.
+if (defined('EXTENDED_DESC_PATH'))
+    include_once(EXTENDED_DESC_PATH . 'include/events.inc.php');
+
 class TwitterCard
 {
   function twittercard_load ($content)
@@ -28,6 +32,9 @@ class TwitterCard
     $title= str_replace('"', '\"',$row['name']);
     $description= str_replace('"', '\"',$row['comment']);
 
+    // Parse language tags in description if possible.
+    if (function_exists('get_user_language_desc'))
+        $description = get_user_language_desc($description);
 
     // Check if folder exists
     $thumbFolder = PHPWG_PLUGINS_PATH . basename(dirname(dirname(__FILE__))) . '/thumbs/' . dirname($url);


### PR DESCRIPTION
This plugin works great and makes sharing pictures a breeze! However, I recently updated my photo descriptions with multi-language tags thanks to the ExtendedDescription plugin, and those tags appeared as-is in the Twitter Card's description.

This change checks whether the ExtendedDescription plugin is available, in which case it uses the language-tag parsing function to generate a clean description, either in the default language or the desired one by adding '?LANG=<relevant language code>' to the picture URL.